### PR TITLE
COSA-985 / Prevent Active Storage issue

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,6 +45,8 @@ Rails.application.configure do
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 
+  config.active_storage.service = :local
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -37,6 +37,8 @@ Rails.application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
+  config.active_storage.service = :local
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 end


### PR DESCRIPTION
### Jira Ticket 

https://ombulabs.atlassian.net/browse/COSA-985

### Motivation / Context

During the first pair session, there was an issue trying to upload attachments with ActiveStorage, we couldn't find a solution in the pair session because the failure happens too deep into Rails' internals so it was a waste of time.

This PR prevents that problem by setting the configuration that was missing (that would be there in a normal new Rails 6.1 application).
    
### QA / Testing Instructions

It not easy to test/qa, you have to do the setup to use ActiveStorage to add attachments to stories and test with and without these config values.
___

I will abide by the [code of conduct](https://github.com/fastruby/points/blob/main/CODE_OF_CONDUCT.md).
