### PR TITLE
Fix spec text on create new project redirect

### DIFF
--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe ProjectsController, type: :controller do
         }.to change(Project, :count).by(1)
       end
 
-      it "redirects to the new project" do
+      it "redirects to the projects" do
         post :create, params: {project: valid_params}
 
         expect(response).to redirect_to "/projects"


### PR DESCRIPTION
### Jira Ticket

No ticket so far

### Motivation / Context

One of the first tasks during the interview process is to update where we redirect after creating a project.

The title of this spec is wrong because we are redirecting to all the project list paths.

### QA / Testing Instructions

<!--- List the steps required to review the changes locally or in staging -->

### Screenshots:

<!-- Add screenshots (applicable to any UI changes) -->
